### PR TITLE
check for error code of 'NoError'

### DIFF
--- a/src/sputils/doesMsgHaveError.js
+++ b/src/sputils/doesMsgHaveError.js
@@ -14,7 +14,7 @@ define(["jquery"], function($){
             spErrCode   = $msg.find("ErrorCode"),
             response    = false;
 
-        if ( !spErrCode.length ) {
+        if ( !spErrCode.length || spErrCode.text() === "NoError") {
 
             if ( $msg.find("faultcode").length ) {
 

--- a/src/sputils/doesMsgHaveError.js
+++ b/src/sputils/doesMsgHaveError.js
@@ -14,7 +14,7 @@ define(["jquery"], function($){
             spErrCode   = $msg.find("ErrorCode"),
             response    = false;
 
-        if ( !spErrCode.length || spErrCode.text() === "NoError") {
+        if ( !spErrCode.length ) {
 
             if ( $msg.find("faultcode").length ) {
 
@@ -27,8 +27,8 @@ define(["jquery"], function($){
         }
 
         spErrCode.each(function(){
-
-            if ( $(this).text() !== "0x00000000" ) {
+			            
+            if ( $(this).text() !== "0x00000000" && $(this).text() !== "NoError" ) {
 
                 response = true;
                 return false;

--- a/test/server/login.operation.response.cannotBeNull.xml
+++ b/test/server/login.operation.response.cannotBeNull.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <soap:Fault>
+            <faultcode>soap:Server</faultcode>
+            <faultstring>Server was unable to process request. ---&gt; Value cannot be null.
+                Parameter name: userName
+            </faultstring>
+            <detail/>
+        </soap:Fault>
+    </soap:Body>
+</soap:Envelope>

--- a/test/server/login.operation.response.noError.xml
+++ b/test/server/login.operation.response.noError.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <LoginResponse xmlns="http://schemas.microsoft.com/sharepoint/soap/">
+            <LoginResult>
+                <CookieName>FedAuth</CookieName>
+                <ErrorCode>NoError</ErrorCode>
+                <TimeoutSeconds>1800</TimeoutSeconds>
+            </LoginResult>
+        </LoginResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/test/server/login.operation.response.passwordNotMatch.xml
+++ b/test/server/login.operation.response.passwordNotMatch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <LoginResponse xmlns="http://schemas.microsoft.com/sharepoint/soap/">
+            <LoginResult>
+                <ErrorCode>PasswordNotMatch</ErrorCode>
+                <TimeoutSeconds>0</TimeoutSeconds>
+            </LoginResult>
+        </LoginResponse>
+    </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
A successful login with `$().SPServices({operation: 'Login'});` yields the following:
```
<?xml version="1.0" encoding="utf-8"?>
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
    <soap:Body>
        <LoginResponse xmlns="http://schemas.microsoft.com/sharepoint/soap/">
            <LoginResult>
                <CookieName>FedAuth</CookieName>
                <ErrorCode>NoError</ErrorCode>
                <TimeoutSeconds>1800</TimeoutSeconds>
            </LoginResult>
        </LoginResponse>
    </soap:Body>
</soap:Envelope>
```
Where `<ErrorCode>` is `NoError` and therefore matched as an error.